### PR TITLE
Let user decide what to do if logger is not in context

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -4,11 +4,11 @@ import (
 	"context"
 )
 
-var disabledLogger *Logger
+var DefaultLogger *Logger
 
 func init() {
 	l := Nop()
-	disabledLogger = &l
+	DefaultLogger = &l
 }
 
 type ctxKey struct{}
@@ -43,5 +43,5 @@ func Ctx(ctx context.Context) *Logger {
 	if l, ok := ctx.Value(ctxKey{}).(*Logger); ok {
 		return l
 	}
-	return disabledLogger
+	return DefaultLogger
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -24,7 +24,7 @@ func TestCtx(t *testing.T) {
 	}
 
 	log2 = Ctx(context.Background())
-	if log2 != disabledLogger {
+	if log2 != DefaultLogger {
 		t.Error("Ctx did not return the expected logger")
 	}
 }

--- a/log.go
+++ b/log.go
@@ -235,7 +235,7 @@ func (l Logger) With() Context {
 //
 // Use this method with caution. If unsure, prefer the With method.
 func (l *Logger) UpdateContext(update func(c Context) Context) {
-	if l == disabledLogger {
+	if l == DefaultLogger {
 		return
 	}
 	if cap(l.context) == 0 {


### PR DESCRIPTION
As for now disabledLogger is being returned if user tries to get logger from context.Context.
Such a behaviour may be beneficial, but in other cases it will be harmful.
Giving user an option to return nil and fail with nil pointer error may prevent logs loss.